### PR TITLE
Option to create index.html files in sub directories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -233,7 +233,7 @@ StaticSitePlugin.prototype.apply = function(compiler) {
 
           const route = renderProps.routes[renderProps.routes.length - 1]; // See NOTE
           const body = renderToString(component);
-          const assetKey = getAssetKey(location);
+          const assetKey = getAssetKey(location, options.indexPaths);
           const doc = this.render({
             ...addHash(options, compilation.hash),
             title: route.title,

--- a/src/utils.js
+++ b/src/utils.js
@@ -230,7 +230,7 @@ export const getAllPaths = (routes: RouteShape | RouteShape[]): string[] => {
  * assumed that this is a 404 route. See the RR changelong for details:
  * https://github.com/rackt/react-router/blob/1.0.x/CHANGES.md#notfound-route
  */
-export const getAssetKey = (location: string): string => {
+export const getAssetKey = (location: string, indexPaths : boolean): string => {
   const basename = path.basename(location);
   const dirname = path.dirname(location).slice(1); // See NOTE above
   let filename;
@@ -240,7 +240,7 @@ export const getAssetKey = (location: string): string => {
   } else if (basename === '*') {
     filename = '404.html';
   } else {
-    filename = basename + '.html';
+    filename = basename + (indexPaths ? '/index' : '') + '.html';
   }
 
   return dirname ? (dirname + path.sep + filename) : filename;


### PR DESCRIPTION
I thought this might be a nice option.

To ensure paths between ReactRouter and the generated HTML files are consistent, paths are exported as a directory with an index.html inside. e.g.

/about/index.html
/about/team/index.html

This is particularly helpful when deploying to S3.

It's now an option on the plugin:

```javascript
new ReactStaticPlugin({
  routes: './path/to/routes.js',
  template: './path/to/template.js',
  indexPaths: true
})
```