### PR TITLE
Add options check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const renderToStaticDocument = (Component, props) => {
 };
 
 const validateOptions = (options) => {
-  if (!options.routes) {
+  if (!options || !options.routes) {
     throw new Error('No routes param provided');
   }
 


### PR DESCRIPTION
The `validateOptions` assumes `options` is defined.

Before output : 
```
if (!options.routes) {
              ^

TypeError: Cannot read property 'routes' of undefined
    at validateOptions (/Users/bob/Documents/foo/node_modules/react-static-webpack-plugin/dist/index.js:41:15)
    at new StaticSitePlugin (/Users/bob/Documents/foo/node_modules/react-static-webpack-plugin/dist/index.js:51:3)
    at Object.<anonymous> (/Users/bob/Documents/foo/webpack.config.js:16:5)
```

After : 
```
throw new Error('No routes param provided');
    ^

Error: No routes param provided
    at validateOptions (/Users/bob/Documents/foo/node_modules/react-static-webpack-plugin/dist/index.js:42:11)
    at new StaticSitePlugin (/Users/bob/Documents/foo/node_modules/react-static-webpack-plugin/dist/index.js:51:3)
    at Object.<anonymous> (/Users/bob/Documents/foo/webpack.config.js:16:5)
```