### PR TITLE
Feat(routes): Can use plain routes

### DIFF
--- a/example/extract-css/webpack.config.prod.js
+++ b/example/extract-css/webpack.config.prod.js
@@ -29,7 +29,7 @@ module.exports = {
       compressor: { warnings: false },
     }),
     new ReactStaticPlugin({
-      routes: './src/components/App.js',
+      component: './src/components/App.js',
       template: './template.js',
       stylesheet: '/app.css',
     }),

--- a/src/utils.js
+++ b/src/utils.js
@@ -161,9 +161,10 @@ export const compileAsset: CompileAsset = (opts) => {
   });
 };
 
+// can be an React Element or a POJO
 type RouteShape = {
   component?: any,
-  props: Object,
+  props?: Object,
   childRoutes?: Object[],
   path?: string,
 }
@@ -187,19 +188,21 @@ type RouteShape = {
  *
  * getAllPaths(routes); => ['/', '/about]
  */
-type GetNestedPaths = (a: RouteShape | RouteShape[], b: ?string) => any[];
+type GetNestedPaths = (a?: RouteShape | RouteShape[], b?: string) => any[];
 export const getNestedPaths: GetNestedPaths = (route, prefix = '') => {
   if (!route) return [];
 
   if (Array.isArray(route)) return route.map(x => getNestedPaths(x, prefix));
 
+  let path = route.props && route.props.path || route.path;
   // Some routes such as redirects or index routes do not have a path. Skip
   // them.
-  if (!route.props.path) return [];
+  if (!path) return [];
 
-  const path = prefix + route.props.path;
+  path = prefix + path;
   const nextPrefix = path === '/' ? path : path + '/';
-  return [path, ...getNestedPaths(route.props.children, nextPrefix)];
+  const childRoutes = route.props && route.props.children || route.childRoutes;
+  return [path, ...getNestedPaths(childRoutes, nextPrefix)];
 };
 
 export const getAllPaths = (routes: RouteShape | RouteShape[]): string[] => {
@@ -303,6 +306,7 @@ export const renderSingleComponent: RenderSingleComponent = (imported, options, 
   }
 
   try {
+    debug('Rendering single component.');
     body = renderToString(component);
   } catch (err) {
     throw new Error(`Invalid single component. Make sure you added your component as the default export from ${options.routes}`);

--- a/test.js
+++ b/test.js
@@ -103,6 +103,55 @@ test('Ignores index routes when generating paths', t => {
   ]);
 });
 
+test('Can get paths from plain routes', t => {
+  const routes = {
+    path: '/',
+    component: Layout,
+    childRoutes: [{
+      path: 'about',
+      component: About,
+    }, {
+      path: 'products',
+      component: Products,
+      childRoutes: [{
+        path: 'zephyr',
+        component: Product
+      }, {
+        path: 'sparkles',
+        component: Product
+      }, {
+        path: 'jarvis',
+        component: Product
+      }]
+    }, {
+      path: 'contact',
+      component: Contact
+    }]
+  };
+
+  const paths = getAllPaths(routes);
+
+  t.deepEqual(paths, [
+    '/',
+    '/about',
+    '/products',
+    '/products/zephyr',
+    '/products/sparkles',
+    '/products/jarvis',
+    '/contact',
+  ]);
+
+  t.deepEqual(paths.map(getAssetKey), [
+    'index.html',
+    'about.html',
+    'products.html',
+    'products/zephyr.html',
+    'products/sparkles.html',
+    'products/jarvis.html',
+    'contact.html',
+  ]);
+});
+
 test('Can get paths from nested routes', t => {
   const routes = (
     <Route path='/' component={Layout}>


### PR DESCRIPTION
This changes the single route to explicitly use `component` instead of implicitly detecting whether routes is actually a routes element or a single component. 
Now  `getNestedRoutes` accommodate both plain route objects and route react elements.

closes #19 
