### PR TITLE
Enhance errors from single component render

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,7 @@ export type OptionsShape = {
   bundle?: string,
   stylesheet?: string,
   favicon?: string,
+  component?: string,
 
   src?: string, // Deprecated. Use routes instead
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -354,7 +354,9 @@ export const renderSingleComponent: RenderSingleComponent = (imported, options, 
     debug('Rendering single component.');
     body = renderToString(component);
   } catch (err) {
-    throw new Error(`Invalid single component. Make sure you added your component as the default export from ${options.routes}`);
+    const componentPath = options.component || '';
+    const pluginErrMsg = `Invalid single component.\nMake sure you added your component as the default export from ${componentPath}.`;
+    throw new Error(`${pluginErrMsg}\n${err.message}`);
   }
 
   const doc = render({


### PR DESCRIPTION
The errors from component-rendering can be very helpful, so this PR appends the `catch` block's error message to the error being created inside of that block. 

The path reference for the component being rendered has been been changed to `options.component` from `options.routes`, [which will be falsy in this context](https://github.com/iansinnott/react-static-webpack-plugin/blob/master/src/index.js#L238).

`component` has also been added to the `OptionsShape` type.